### PR TITLE
Fix typo in license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ const response = await generateLayout({
 
 ## 📝 License
 
-Dieses Projekt ist unter der MIT License lizensiert - siehe [LICENSE](LICENSE) für Details.
+Dieses Projekt ist unter der MIT License lizenziert - siehe [LICENSE](LICENSE) für Details.
 
 ## 💬 Support
 


### PR DESCRIPTION
## Summary
- correct 'lizensiert' to 'lizenziert' in README

## Testing
- `npm test` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa3c22f988324875c39675b15ce82