### PR TITLE
fix: relocate section components import

### DIFF
--- a/src/features/visual-builder/pages/visual-builder-page.tsx
+++ b/src/features/visual-builder/pages/visual-builder-page.tsx
@@ -7,6 +7,12 @@ import { Button } from '../../../components/ui/button'
 import { Input } from '../../../components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle } from '../../../components/ui/card'
 import { useToast } from '../../../components/ui/toast'
+import {
+  SectionRenderer,
+  SectionsPanel,
+  PropertiesPanel,
+  AIPanel,
+} from '../components/section-components'
 
 // Types für den Visual Builder
 interface Section {
@@ -566,5 +572,3 @@ function getDefaultStyles(type: Section['type']): Record<string, any> {
       return baseStyles
   }
 }
-
-import { SectionRenderer, SectionsPanel, PropertiesPanel, AIPanel } from '../components/section-components'


### PR DESCRIPTION
## Summary
- move the section component imports to the top of `visual-builder-page.tsx`
- remove leftover import at file end

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa3d275dc83249b64ba667d722292